### PR TITLE
Nulls highres profile picture url after profile pic is deleted

### DIFF
--- a/files/routes/settings.py
+++ b/files/routes/settings.py
@@ -364,7 +364,7 @@ def settings_images_banner(v):
 @auth_required
 @validate_formkey
 def settings_delete_profile(v):
-
+	v.highres = None
 	v.profileurl = None
 	g.db.add(v)
 	return render_template("settings_profile.html", v=v,
@@ -374,7 +374,7 @@ def settings_delete_profile(v):
 @auth_required
 @validate_formkey
 def settings_delete_banner(v):
-	v.highres = None
+	
 	v.bannerurl = None
 	g.db.add(v)
 

--- a/files/routes/settings.py
+++ b/files/routes/settings.py
@@ -374,7 +374,7 @@ def settings_delete_profile(v):
 @auth_required
 @validate_formkey
 def settings_delete_banner(v):
-	
+
 	v.bannerurl = None
 	g.db.add(v)
 

--- a/files/routes/settings.py
+++ b/files/routes/settings.py
@@ -374,7 +374,7 @@ def settings_delete_profile(v):
 @auth_required
 @validate_formkey
 def settings_delete_banner(v):
-
+	v.highres = None
 	v.bannerurl = None
 	g.db.add(v)
 


### PR DESCRIPTION
There is an issue where if a user has a profile picture and they delete it, this url is not unset. A user's profile will show one of the random profile pictures, but the <a> href url is still to the old profile picture, so clicking on the random picture redirects to the old picture.