### PR TITLE
cache comment_count in submission

### DIFF
--- a/files/classes/submission.py
+++ b/files/classes/submission.py
@@ -52,6 +52,7 @@ class Submission(Base, Stndrd, Age_times, Scores, Fuzzing):
 	stickied = Column(Boolean, default=False)
 	is_pinned = Column(Boolean, default=False)
 	private = Column(Boolean, default=False)
+	comment_count = Column(Integer, default=0)
 	comments = relationship(
 		"Comment",
 		lazy="joined",
@@ -94,11 +95,6 @@ class Submission(Base, Stndrd, Age_times, Scores, Fuzzing):
 
 	def __repr__(self):
 		return f"<Submission(id={self.id})>"
-
-	@property
-	@lazy
-	def comment_count(self):
-		return len(self.comments)
 
 	@property
 	@lazy

--- a/files/routes/comments.py
+++ b/files/routes/comments.py
@@ -269,8 +269,14 @@ def api_comment(v):
 				app_id=v.client.application.id if v.client else None,
 				shadowbanned=v.shadowbanned
 				)
+
 	g.db.add(c)
 	g.db.flush()
+
+	parent_post.comment_count = g.db.query(Comment).filter_by(parent_submission=parent_post.id).count()
+	g.db.add(parent_post)
+	g.db.flush()
+
 	if request.files.get("file") and request.headers.get("cf-ipcountry") != "T1":
 		file=request.files["file"]
 		if not file.content_type.startswith('image/'): return {"error": "That wasn't an image!"}, 400

--- a/files/routes/comments.py
+++ b/files/routes/comments.py
@@ -273,10 +273,6 @@ def api_comment(v):
 	g.db.add(c)
 	g.db.flush()
 
-	parent_post.comment_count = g.db.query(Comment).filter_by(parent_submission=parent_post.id).count()
-	g.db.add(parent_post)
-	g.db.flush()
-
 	if request.files.get("file") and request.headers.get("cf-ipcountry") != "T1":
 		file=request.files["file"]
 		if not file.content_type.startswith('image/'): return {"error": "That wasn't an image!"}, 400
@@ -511,6 +507,9 @@ def api_comment(v):
 	v.comment_count = v.comments.filter(Comment.parent_submission != None).filter_by(is_banned=False, deleted_utc=0).count()
 	g.db.add(v)
 
+	parent_post.comment_count = g.db.query(Comment).filter_by(parent_submission=parent_post.id).count()
+	g.db.add(parent_post)
+	g.db.flush()
 
 	if request.headers.get("Authorization"): return c.json
 	else: return jsonify({"html": render_template("comments.html",

--- a/files/routes/front.py
+++ b/files/routes/front.py
@@ -136,7 +136,7 @@ def frontlist(v=None, sort="hot", page=1, t="all", ids_only=True, filter_words='
 	elif sort == "bottom":
 		posts = sorted(posts.all(), key=lambda x: x.score)
 	elif sort == "comments":
-		posts = sorted(posts.all(), key=lambda x: x.comment_count, reverse=True)
+		posts = posts.order_by(Submission.comment_count.desc()).all()
 	elif sort == "random":
 		posts = posts.all()
 		posts = random.sample(posts, k=len(posts))

--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -884,6 +884,9 @@ def submit_post(v):
 	g.db.add(c)
 	g.db.flush()
 
+	new_post.comment_count = g.db.query(Comment).filter_by(parent_submission=new_post.id).count()
+	g.db.add(new_post)
+
 	if "rdrama" in request.host:
 		if v.id == 995: body = "fuck off carp"
 		else: body = random.choice(snappyquotes)


### PR DESCRIPTION
right now sorting by all time comment count times out. thats because for every post backend makes a database call to count comments. 

```
ALTER TABLE submissions add column comment_count integer default 0;
update submissions set comment_count=(select count(id) from comments where parent_submission=submissions.id);
```

also should slightly (unnoticeably) improve front page load times because the same thing happens there (25 database calls to count comments)