### PR TITLE
transform post/comment links in ban reason

### DIFF
--- a/files/classes/user.py
+++ b/files/classes/user.py
@@ -201,6 +201,15 @@ class User(Base):
 
 	@property
 	@lazy
+	def ban_reason_link(self):
+		if not self.ban_reason:
+			return self.ban_reason
+
+		if self.ban_reason.startswith("/post/") or self.ban_reason.startswith("/comment/"):
+			return self.ban_reason.split(" ", 1)[0]
+
+	@property
+	@lazy
 	def alts_unique(self):
 		alts = []
 		for u in self.alts:

--- a/files/classes/user.py
+++ b/files/classes/user.py
@@ -202,10 +202,7 @@ class User(Base):
 	@property
 	@lazy
 	def ban_reason_link(self):
-		if not self.ban_reason:
-			return self.ban_reason
-
-		if self.ban_reason.startswith("/post/") or self.ban_reason.startswith("/comment/"):
+		if self.ban_reason and (self.ban_reason.startswith("/post/") or self.ban_reason.startswith("/comment/")):
 			return self.ban_reason.split(" ", 1)[0]
 
 	@property

--- a/files/templates/userpage.html
+++ b/files/templates/userpage.html
@@ -122,7 +122,11 @@
 						</div>
 						<div class="ml-3 w-100">
 							{% if u.is_suspended %}
-								<h5 style="color:#ff66ac;">BANNED USER{% if u.ban_reason %}: {{u.ban_reason}}{% endif %}</h5>
+								<h5 style="color:#ff66ac;">BANNED USER{% if u.ban_reason %}:
+									{% if u.ban_reason_link %}<a href="{{ u.ban_reason_link }}"><i class="fas fa-link"></i>{% endif %}
+										{{ u.ban_reason }}
+									{% if u.ban_reason_link %}</a>{% endif %}
+								{% endif %}</h5>
 								{% if u.unban_utc %}<h5 style="color:#ff66ac;">{{u.unban_string}}</h5>{% endif %}
 							{% endif %}
 							<div class="d-flex align-items-center mt-1 mb-2">


### PR DESCRIPTION
When the ban reason begins with `/comment/...` or `/post/...` then a little link icon is displayed and the reason sends the user to that comment/post.
<img width="420" alt="Screenshot 2021-11-24 at 15 43 37" src="https://user-images.githubusercontent.com/90930628/143269995-db9d0209-6129-41e2-8477-22b2c4529222.png">

Works correctly when there's `/comment/...` or `/post/...` and additional words words words.
<img width="478" alt="Screenshot 2021-11-24 at 15 43 15" src="https://user-images.githubusercontent.com/90930628/143269992-77c3d8e5-8ded-4e7e-864e-7e948adac5bd.png">

When no `/comment/...` or `/post/...` is available in the ban reason then there's no hyperlink.
<img width="442" alt="Screenshot 2021-11-24 at 15 42 49" src="https://user-images.githubusercontent.com/90930628/143269986-d0779305-29b7-4a82-b40a-222f31f6bdcf.png">
