### PR TITLE
Update popover.js

### DIFF
--- a/files/assets/js/popover.js
+++ b/files/assets/js/popover.js
@@ -1,4 +1,3 @@
-window.onload = function() {
   function eventasdf(value){
       var content_id = value.getAttributeNode("data-content-id").value;
       value.addEventListener("click", function(){jhkj(content_id)});
@@ -33,4 +32,3 @@ window.onload = function() {
     usernames.forEach(eventasdf);
     
     document.addEventListener("click", function(e){dfgh(e)});
-  };


### PR DESCRIPTION
using window.onload is causing the script to never execute. is there a reason it has to be used? calling the script with defer should be enough to make sure it runs at the proper time.