### PR TITLE
Lock posts/comments

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -4288,6 +4288,10 @@ div.banned {
     background-color: #960000 !important;
     border-left: 3px solid #ff0000 !important;
 }
+div.locked {
+    background-color: #98a300 !important;
+    border-left: 3px solid #f2f7b3 !important;
+}
 div.deleted {
     background-color: #4a4a15 !important;
 }

--- a/files/assets/js/comments_admin.js
+++ b/files/assets/js/comments_admin.js
@@ -40,6 +40,48 @@ function approveComment(post_id,button1,button2) {
 	}
 }
 
+function lockComment(post_id,button1,button2) {
+	url="/lock_comment/"+post_id
+
+	post(url)
+
+	try {
+		document.getElementById("comment-"+post_id+"-only").classList.add("locked");
+	} catch(e) {
+		document.getElementById("context").classList.add("locked");
+	}
+
+	var button=document.getElementById("lock-"+post_id);
+	button.onclick=function(){unlockComment(post_id)};
+	button.innerHTML='<i class="fas fa-clipboard-check"></i>Unlock'
+
+	if (typeof button1 !== 'undefined') {
+		document.getElementById(button1).classList.toggle("d-md-inline-block");
+		document.getElementById(button2).classList.toggle("d-md-inline-block");
+	}
+};
+
+function unlockComment(post_id,button1,button2) {
+	url="/unlock_comment/"+post_id
+
+	post(url)
+
+	try {
+		document.getElementById("comment-"+post_id+"-only").classList.remove("locked");
+	} catch(e) {
+		document.getElementById("context").classList.remove("locked");
+	}
+
+	var button=document.getElementById("lock-"+post_id);
+	button.onclick=function(){lockComment(post_id)};
+	button.innerHTML='<i class="fas fa-trash-alt"></i>Lock'
+
+	if (typeof button1 !== 'undefined') {
+		document.getElementById(button1).classList.toggle("d-md-inline-block");
+		document.getElementById(button2).classList.toggle("d-md-inline-block");
+	}
+}
+
 
 function removeComment2(post_id,button1,button2) {
 	url="/ban_comment/"+post_id

--- a/files/classes/comment.py
+++ b/files/classes/comment.py
@@ -22,6 +22,7 @@ class Comment(Base):
 	created_utc = Column(Integer, default=0)
 	edited_utc = Column(Integer, default=0)
 	is_banned = Column(Boolean, default=False)
+	is_locked = Column(Boolean, default=False)
 	ghost = Column(Boolean)
 	bannedfor = Column(Boolean)
 	distinguish_level = Column(Integer, default=0)
@@ -260,6 +261,7 @@ class Comment(Base):
 			'created_utc': self.created_utc,
 			'edited_utc': self.edited_utc or 0,
 			'is_banned': bool(self.is_banned),
+			'is_locked': bool(self.is_locked),
 			'deleted_utc': self.deleted_utc,
 			'is_nsfw': self.over_18,
 			'permalink': self.permalink,

--- a/files/classes/submission.py
+++ b/files/classes/submission.py
@@ -22,6 +22,7 @@ class Submission(Base):
 	created_utc = Column(BigInteger, default=0)
 	thumburl = Column(String)
 	is_banned = Column(Boolean, default=False)
+	is_locked = Column(Boolean, default=False)
 	bannedfor = Column(Boolean)
 	ghost = Column(Boolean)
 	views = Column(Integer, default=0)
@@ -252,6 +253,7 @@ class Submission(Base):
 		data = {'author_name': self.author_name if self.author else '',
 				'permalink': self.permalink,
 				'is_banned': bool(self.is_banned),
+				'is_locked': bool(self.is_locked),
 				'deleted_utc': self.deleted_utc,
 				'created_utc': self.created_utc,
 				'id': self.id,

--- a/files/routes/comments.py
+++ b/files/routes/comments.py
@@ -280,6 +280,12 @@ def api_comment(v):
 	if parent.author.any_block_exists(v) and v.admin_level < 2:
 		return {"error": "You can't reply to users who have blocked you, or users you have blocked."}, 403
 
+	if parent.is_locked and v.admin_level < 2:
+		return {"error": "You can't reply to locked comments."}, 403
+
+	if parent_post.is_locked and v.admin_level < 2:
+		return {"error": "You can't comment under locked posts."}, 403
+
 	is_bot = bool(request.headers.get("Authorization"))
 
 	if not is_bot and not v.marseyawarded and AGENDAPOSTER_PHRASE not in body.lower() and len(body) > 10:

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -193,7 +193,7 @@
 	{% endif %}
 	<div class="comment-body">
 
-		<div id="{% if comment_info and comment_info.id == c.id %}context{%else%}comment-{{c.id}}-only{% endif %}" class="comment-anchor {% if comment_info and comment_info.id == c.id %}context{%endif%}{% if c.is_banned %} banned{% endif %}{% if c.deleted_utc %} deleted{% endif %}">
+		<div id="{% if comment_info and comment_info.id == c.id %}context{%else%}comment-{{c.id}}-only{% endif %}" class="comment-anchor {% if comment_info and comment_info.id == c.id %}context{%endif%}{% if c.is_banned %} banned{% endif %}{% if c.is_locked %} locked{% endif %}{% if c.deleted_utc %} deleted{% endif %}">
 
 			<div class="user-info">
 				<span class="comment-collapse-icon" onclick="collapse_comment('{{c.id}}')"></span>
@@ -286,6 +286,10 @@
 
 			{% if c.is_banned and c.ban_reason %}
 				<div id="comment-banned-warning" class="comment-text text-removed mb-0">removed by @{{c.ban_reason}}</div>
+			{% endif %}
+
+			{% if c.is_locked %}
+				<div id="comment-banned-warning" class="comment-text text-removed mb-0">locked by @{{c.ban_reason}}</div>
 			{% endif %}
 
 			<div id="comment-text-{{c.id}}" class="comment-text mb-0 {% if c.author.agendaposter %}agendaposter{% endif %}" >
@@ -500,6 +504,11 @@
 								<button id="approve-{{c.id}}" class="btn caction py-0 nobackground px-1 text-success d-none {% if c.is_banned %}d-md-inline-block{% endif %} text-success" onclick="approveComment('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}')"><i class="fas fa-check text-success fa-fw"></i>Approve</button>
 								<button id="remove-{{c.id}}" class="btn caction py-0 nobackground px-1 text-danger d-none {% if not c.is_banned %}d-md-inline-block{% endif %} text-danger" onclick="removeComment('{{c.id}}','approve-{{c.id}}','remove-{{c.id}}')"><i class="fas fa-ban text-danger fa-fw"></i>Remove</button>
 							{% endif %}
+						{% endif %}
+
+						{% if v and v.admin_level > 1 %}
+								<button id="unlock-{{c.id}}" class="btn caction py-0 nobackground px-1 text-success d-none {% if c.is_locked %}d-md-inline-block{% endif %} text-success" onclick="unlockComment('{{c.id}}','unlock-{{c.id}}','lock-{{c.id}}')"><i class="fas fa-check text-success fa-fw"></i>Unlock</button>
+								<button id="lock-{{c.id}}" class="btn caction py-0 nobackground px-1 text-danger d-none {% if not c.is_locked %}d-md-inline-block{% endif %} text-danger" onclick="lockComment('{{c.id}}','unlock-{{c.id}}','lock-{{c.id}}')"><i class="fas fa-ban text-danger fa-fw"></i>Lock</button>
 						{% endif %}
 						
 						{% if v and c.parent_submission and (c.author_id==v.id or v.admin_level > 1) %}
@@ -910,7 +919,7 @@
 	<script src="/static/assets/js/clipboard.js?a=220"></script>
 
 	{% if v and v.admin_level > 1 %}
-		<script src="/static/assets/js/comments_admin.js?a=220"></script>
+		<script src="/static/assets/js/comments_admin.js"></script>
 	{% endif %}
 
 	{% include "expanded_image_modal.html" %}

--- a/files/templates/default.html
+++ b/files/templates/default.html
@@ -7,7 +7,7 @@
 	<script src="/static/assets/js/bootstrap.js?a=220"></script>
 	{% if v %}
 		<style>:root{--primary:#{{v.themecolor}}}</style>
-		<link rel="stylesheet" href="/static/assets/css/main.css?a=102">
+		<link rel="stylesheet" href="/static/assets/css/main.css">
 		<link rel="stylesheet" href="/static/assets/css/{{v.theme}}.css?a=14">
 		{% if v.agendaposter %}
 			<style>
@@ -32,7 +32,7 @@
 		{% endif %}
 	{% else %}
 		<style>:root{--primary:#{{config('DEFAULT_COLOR')}}</style>
-		<link rel="stylesheet" href="/static/assets/css/main.css?a=102"><link rel="stylesheet" href="/static/assets/css/{{config('DEFAULT_THEME')}}.css?a=14">
+		<link rel="stylesheet" href="/static/assets/css/main.css"><link rel="stylesheet" href="/static/assets/css/{{config('DEFAULT_THEME')}}.css?a=14">
 	{% endif %}
 
 	<meta charset="utf-8">

--- a/files/templates/submission.html
+++ b/files/templates/submission.html
@@ -409,7 +409,7 @@
 
 	<div id="post-root" class="col-12">
 
-		<div id="post-{{p.id}}" class="card border-0 mt-3{% if p.is_banned %} banned{% endif %}{% if p.stickied %} stickied{% endif %}{% if voted==1 %} upvoted{% elif voted==-1 %} downvoted{% endif %}">
+		<div id="post-{{p.id}}" class="card border-0 mt-3{% if p.is_banned %} banned{% endif %}{% if p.is_locked %} locked{% endif %}{% if p.stickied %} stickied{% endif %}{% if voted==1 %} upvoted{% elif voted==-1 %} downvoted{% endif %}">
 			<div class="{% if p.deleted_utc %}deleted {% endif %}d-flex flex-row-reverse flex-nowrap justify-content-end">
 
 				{% if not p.is_image and p.thumb_url and not p.embed_url %}
@@ -533,6 +533,10 @@
 
 							{% if p.is_banned and p.ban_reason %}
 								<div class="text-removed mb-0">removed by @{{p.ban_reason}}</div>
+							{% endif %}
+
+							{% if p.is_locked and p.ban_reason %}
+								<div class="text-removed mb-0">locked by @{{p.ban_reason}}</div>
 							{% endif %}
 
 						</div>
@@ -663,6 +667,11 @@
 									{% if v.id != p.author.id %}<a id="remove-{{p.id}}" class="{% if p.is_banned %}d-none{% endif %} list-inline-item text-danger" role="button" onclick="post_toast2('/ban_post/{{p.id}}','remove-{{p.id}}','approve-{{p.id}}')"><i class="fas fa-ban"></i>Remove</a>{% endif %}
 									<a id="approve-{{p.id}}" class="{% if not p.is_banned %}d-none{% endif %} list-inline-item text-success" role="button" onclick="post_toast2('/unban_post/{{p.id}}','remove-{{p.id}}','approve-{{p.id}}')"><i class="fas fa-check"></i>Approve</a>
 								{% endif %}
+							{% endif %}
+
+							{% if v.admin_level > 1 %}
+								<a id="lock-{{p.id}}" class="{% if p.is_locked %}d-none{% endif %} list-inline-item text-danger" role="button" onclick="post_toast2('/lock_post/{{p.id}}','lock-{{p.id}}','unlock-{{p.id}}')"><i class="fas fa-ban"></i>Lock</a>
+								<a id="unlock-{{p.id}}" class="{% if not p.is_locked %}d-none{% endif %} list-inline-item text-success" role="button" onclick="post_toast2('/unlock_post/{{p.id}}','lovk-{{p.id}}','unlock-{{p.id}}')"><i class="fas fa-check"></i>Unlock</a>
 							{% endif %}
 
 							{% if v.id == p.author_id or v.admin_level > 1 %}

--- a/schema.sql
+++ b/schema.sql
@@ -277,6 +277,7 @@ CREATE TABLE public.comments (
     created_utc integer NOT NULL,
     parent_submission integer,
     is_banned boolean,
+    is_locked boolean,
     distinguish_level integer,
     edited_utc integer,
     deleted_utc integer NOT NULL,
@@ -599,6 +600,7 @@ CREATE TABLE public.submissions (
     author_id integer,
     created_utc integer NOT NULL,
     is_banned boolean,
+    is_locked boolean,
     over_18 boolean,
     distinguish_level integer,
     deleted_utc integer NOT NULL,
@@ -1652,6 +1654,12 @@ CREATE INDEX submission_domainref_index ON public.submissions USING btree (domai
 --
 
 CREATE INDEX submission_isbanned_idx ON public.submissions USING btree (is_banned);
+
+--
+-- Name: submission_islocked_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX submission_islocked_idx ON public.submissions USING btree (is_locked);
 
 
 --


### PR DESCRIPTION
Hi, it's Buck from rdrama again.

Submissions and comments now have the "is_locked" column. Moderators can lock posts and comments to prevent users from replying. Locked subs/comments have a yellow tint and outline. When a user attempts to reply to a comment, they get an error popup saying "You can't reply to locked comments.", for posts it is "You can't comment under locked posts." Feel free to leave any suggestions and edits.

I don't expect moderators to use this because locking is bad for drama, but it is good for locking gambling chains to prevent people from keeping themselves safe. 

Y'all can't behave!