### PR TITLE
Fixed issue with broken donation link

### DIFF
--- a/files/templates/default.html
+++ b/files/templates/default.html
@@ -220,7 +220,7 @@
 				{% set path = "assets/images/" + SITE_NAME + "/banners_bhm" %}
 				{% set image = "/static/" + path + "/" + listdir('files/' + path)|random() + '?a=21' %}
 
-				<a href="https://secure.actblue.com/donate/ms_blm_homepage_2019">
+				<a href="https://gorillafund.org/adopt">
 					<img alt="site banner" src="{{image}}" width="100%">
 				</a>
 			{% else %}


### PR DESCRIPTION
Currently donation link is broken (From ActBlue: "You have attempted to make a contribution to a fundraising page that has no active recipients: either the page's owner has removed all committees or organizations from the page, or we have concluded processing contributions for these committees or organizations.")

Replaced with working link to appropriate charity

![18334990-6DF9-4E11-9609-653A55761AC7](https://user-images.githubusercontent.com/98491720/153363732-16bd03d5-f420-4ad7-bc2f-70b13726f83b.jpeg)
